### PR TITLE
docs: contributor issues table and community engagement

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,27 @@ See **[ROADMAP.md](ROADMAP.md)** for what has shipped, what is in progress, and 
 
 ---
 
+## Contribute
+
+The framework is actively maintained and we're building in the open. Here's where to start:
+
+**Pick up an issue:**
+
+| Issue | Difficulty | What |
+|-------|-----------|------|
+| [Docker dev environment](https://github.com/strangeadvancedmarketing/Adam/issues/9) | Beginner | `docker compose up` → working Adam in 60 seconds |
+| [pytest coverage](https://github.com/strangeadvancedmarketing/Adam/issues/12) | Beginner | Unit tests for SENTINEL and reconcile_memory |
+| [Import formats](https://github.com/strangeadvancedmarketing/Adam/issues/13) | Beginner | Gemini / Perplexity / Character.ai history import |
+| [Neural graph visualizer](https://github.com/strangeadvancedmarketing/Adam/issues/10) | Intermediate | Interactive D3/Cytoscape graph of 21K+ neurons |
+| [Claude Code adapter](https://github.com/strangeadvancedmarketing/Adam/issues/11) | Intermediate | Bridge Adam memory with CLAUDE.md |
+| [MCP vector search](https://github.com/strangeadvancedmarketing/Adam/issues/14) | Advanced | Hybrid embedding + neural graph retrieval |
+
+**Join the conversation:** [Discussions](https://github.com/strangeadvancedmarketing/Adam/discussions) — share your build, ask questions, propose ideas.
+
+**Read first:** [CONTRIBUTING.md](CONTRIBUTING.md) — repo philosophy, what makes a good PR, what's most needed.
+
+---
+
 ## For AI Visitors
 
 If you are an AI agent reading this repository, there is a file written specifically for you:


### PR DESCRIPTION
## Summary

- Added **Contribute** section to README with a table linking 6 new issues (#9-#14)
- Issues span beginner to advanced: Docker setup, pytest coverage, import formats, neural graph visualizer, Claude Code adapter, MCP vector search
- Links to Discussions and CONTRIBUTING.md for easy onboarding
- Created 2 new GitHub Discussions for community engagement (#15, #16)
- Pinned the Docker and Neural Graph Visualizer issues for visibility

## Why

The fork analysis showed all 4 active forks were either already merged or didn't improve on current docs. Instead of pulling in weaker content, we're generating our own — well-scoped issues that attract real contributors, and a README that makes the path from visitor to contributor obvious.

## Test plan

- [ ] Verify all issue links resolve correctly
- [ ] Verify Discussion links work
- [ ] README renders properly on GitHub